### PR TITLE
Add controller to the oc_oob network

### DIFF
--- a/etc/kayobe/controllers.yml
+++ b/etc/kayobe/controllers.yml
@@ -18,6 +18,7 @@ controller_bootstrap_user: centos
 # Modify the default list of networks to remove storage management.
 controller_default_network_interfaces: >
   {{ [provision_oc_net_name,
+      oob_oc_net_name,
       oob_wl_net_name,
       provision_wl_net_name,
       internal_net_name,

--- a/etc/kayobe/inventory/group_vars/controllers/network-interfaces
+++ b/etc/kayobe/inventory/group_vars/controllers/network-interfaces
@@ -9,6 +9,10 @@ oc_provision_interface: brem3
 oc_provision_bridge_ports:
   - em3
 
+# Overcloud OOB network interface. This is to access the Dell PowerConnect
+# Switch.
+oc_oob_interface: "{{ oc_provision_interface }}.{{ oc_oob_vlan }}"
+
 # Workload OOB network interface.
 wl_oob_interface: "{{ oc_provision_interface }}.{{ wl_oob_vlan }}"
 

--- a/etc/kayobe/inventory/group_vars/ctl-switches
+++ b/etc/kayobe/inventory/group_vars/ctl-switches
@@ -76,6 +76,7 @@ switch_interface_config_controller:
   - "switchport general allowed vlan add {{ oc_provision_vlan }} untagged"
   # Current expect-based configuration mechanism requires no line wrapping, so
   # VLANs must be configured individually.
+  - "switchport general allowed vlan add {{ oc_oob_vlan }} tagged"
   - "switchport general allowed vlan add {{ wl_oob_vlan }} tagged"
   - "switchport general allowed vlan add {{ wl_provision_vlan }} tagged"
   - "switchport general allowed vlan add {{ public_vlan }} tagged"

--- a/etc/kayobe/network-allocation.yml
+++ b/etc/kayobe/network-allocation.yml
@@ -5,6 +5,7 @@ internal_ips:
   control-0: 10.12.4.3
   hypervisor-0: 10.12.4.4
 oc_oob_ips:
+  control-0: 10.12.2.127
   sib-seed: 10.12.2.2
 oc_provision_ips:
   ceph-0: 10.12.3.5
@@ -33,4 +34,3 @@ wl_oob_ips:
   control-0: 10.12.7.3
 wl_provision_ips:
   control-0: 10.12.8.3
-

--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -72,6 +72,8 @@ oc_provision_gateway: 10.12.3.1
 oc_oob_cidr: 10.12.2.0/24
 oc_oob_vlan: 72
 oc_oob_physical_network: "{{ sib_mgmt_physical_network }}"
+oc_oob_allocation_pool_start: 10.12.2.127
+oc_oob_allocation_pool_end: 10.12.2.200
 
 # Workload out of band power/management network IP information.
 wl_oob_cidr: 10.12.7.0/24


### PR DESCRIPTION
This is so neutron can access the Dell PowerConnect 6224 switch which has an IP address on the oc_oob network