### PR TITLE
Add a playbook to set baremetal compute resource class

### DIFF
--- a/ansible/baremetal-compute-resource-class.yml
+++ b/ansible/baremetal-compute-resource-class.yml
@@ -1,0 +1,34 @@
+---
+# This playbook will ensure that all baremetal compute nodes are named after
+# their inventory host names. It matches the ipmi address in the inventory to
+# the one gathered from inspection
+
+- name: Set baremetal compute nodes resource class
+  hosts: controllers[0]
+  gather_facts: False
+  vars:
+    venv: "{{ virtualenv_path }}/openstack-cli"
+  pre_tasks:
+    - name: Set up openstack cli virtualenv
+      pip:
+        virtualenv: "{{ venv }}"
+        name:
+          - python-openstackclient
+          - python-ironicclient
+
+- name: Set baremetal compute nodes resource class
+  hosts: baremetal-compute
+  gather_facts: False
+  vars:
+    venv: "{{ virtualenv_path }}/openstack-cli"
+    controller_host: "{{ groups['controllers'][0] }}"
+  tasks:
+    - name: Set resource class
+      command: >
+        {{ venv }}/bin/openstack baremetal node set --resource-class baremetal-A "{{ inventory_hostname }}"
+      delegate_to: "{{ controller_host }}"
+      environment: "{{ openstack_auth_env }}"
+      vars:
+        # NOTE: Without this, the controller's ansible_host variable will not
+        # be respected when using delegate_to.
+        ansible_host: "{{ hostvars[controller_host].ansible_host | default(controller_host) }}"

--- a/ansible/baremetal-compute-resource-class.yml
+++ b/ansible/baremetal-compute-resource-class.yml
@@ -1,7 +1,6 @@
 ---
-# This playbook will ensure that all baremetal compute nodes are named after
-# their inventory host names. It matches the ipmi address in the inventory to
-# the one gathered from inspection
+# This playbook will ensure that all baremetal compute nodes have
+# the baremetal-A resource class set.
 
 - name: Set baremetal compute nodes resource class
   hosts: controllers[0]

--- a/ansible/filter_plugins
+++ b/ansible/filter_plugins
@@ -1,0 +1,1 @@
+../../kayobe/ansible/filter_plugins/

--- a/ansible/group_vars
+++ b/ansible/group_vars
@@ -1,0 +1,1 @@
+../../kayobe/ansible/group_vars/


### PR DESCRIPTION
This is required to prevent servers using the baremetal flavors from being scheduled to VMs.