### PR TITLE
Enable provider networks

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -207,7 +207,7 @@ kolla_enable_etcd: True
 #kolla_enable_neutron_qos:
 #kolla_enable_neutron_agent_ha:
 #kolla_enable_neutron_bgp_dragent:
-#kolla_enable_neutron_provider_networks:
+kolla_enable_neutron_provider_networks: yes
 #kolla_enable_nova_serialconsole_proxy:
 #kolla_enable_octavia:
 #kolla_enable_osprofiler:

--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -33,7 +33,9 @@ internal_net_name: internal
 # Deprecated name: external_net_name
 # If external_net_name is defined, external_net_names will default to a list
 # containing one item, external_net_name.
-external_net_names: []
+external_net_names:
+  # This causes the openvswitch to be created
+  - oc_provision
 
 # Name of the network used to expose the public OpenStack API endpoints.
 public_net_name: public


### PR DESCRIPTION
We add the oc_provision network to the list of external networks
in order to force kayobe to create the virtual patch links that connect
the external network bridges to the Neutron OVS bridge