### PR TITLE
Nova requires cinder keyring in order to attach remote volumes

### DIFF
--- a/etc/kayobe/kolla/config/nova/ceph.client.cinder.keyring
+++ b/etc/kayobe/kolla/config/nova/ceph.client.cinder.keyring
@@ -1,0 +1,2 @@
+[client.cinder]
+key = {{ secrets_ceph_client_cinder }}


### PR DESCRIPTION
Requires: https://github.com/stackhpc/kolla-ansible/pull/48